### PR TITLE
feat: handle path separators in album folder template

### DIFF
--- a/internal/service/zvuk/album.go
+++ b/internal/service/zvuk/album.go
@@ -112,11 +112,23 @@ func (s *ServiceImpl) registerAlbumCollection(
 
 	// Generate a folder name for the album if it's not a single or if singles require folders
 	if !isSingleWithoutFolder {
-		albumFolderName = utils.SanitizeFilename(s.templateManager.GetAlbumFolderName(ctx, albumTags))
+		// Get the raw folder name template result
+		rawAlbumFolderName := s.templateManager.GetAlbumFolderName(ctx, albumTags)
+
+		// Split the path by '/', sanitize each component, and join them using the OS path separator
+		pathComponents := strings.Split(rawAlbumFolderName, "/")
+		sanitizedComponents := make([]string, len(pathComponents))
+		for i, component := range pathComponents {
+			// Sanitize each part of the path individually
+			sanitizedComponents[i] = utils.SanitizeFilename(component)
+		}
+		albumFolderName = filepath.Join(sanitizedComponents...) // Join components using OS-specific separator
+
+		// Truncate the final combined path if necessary
 		albumFolderName = s.truncateFolderName(ctx, "Album", albumFolderName)
 	}
 
-	// Create the album folder
+	// Create the album folder path by joining with the base output path
 	albumPath := filepath.Join(s.cfg.OutputPath, albumFolderName)
 
 	err := os.MkdirAll(albumPath, defaultFolderPermissions)


### PR DESCRIPTION
I needed a feature to handle album folder paths generated from the `album_folder_template`. I'm not sure if this qualifies as an issue, but I decided to implement it and propose this change.

Previously, the path was sanitized as a whole, replacing slashes (`/`) with underscores (`_`), which prevented the creation of nested directories. For example, the following configuration:

```yaml
album_folder_template: "{{.albumArtist}}/{{.albumTitle}} ({{.releaseYear}})"
```

would incorrectly result in a path like `Artist_Name_Album_Title (2023)` instead of the expected `Artist Name/Album Title (2023)`.

The changes made in this PR:
- Split the path by `/` and sanitize each component individually.
- Rejoin the components using the OS-specific path separator.

This enhancement allows for the intended directory structure to be maintained, improving the organization of downloaded albums.
