### PR TITLE
Added tag sanitization when they used for album folder path

### DIFF
--- a/internal/service/zvuk/template_manager.go
+++ b/internal/service/zvuk/template_manager.go
@@ -190,14 +190,12 @@ func (s *TemplateManagerImpl) GetAlbumFolderName(ctx context.Context, tags map[s
 
 	var sanitizedTags = make(map[string]string, len(tags))
 	for key, val := range tags {
-		//fmt.Println(key, " -> ", val)
 		sanitizedTags[key] = utils.SanitizeFilename(val)
 	}
 
 	// Execute the template with the album tags.
 	if textBuilder != nil {
 		err := textBuilder.Execute(&buffer, sanitizedTags)
-		//err := textBuilder.Execute(&buffer, tags)
 		if err != nil {
 			logger.Errorf(
 				ctx,
@@ -210,13 +208,11 @@ func (s *TemplateManagerImpl) GetAlbumFolderName(ctx context.Context, tags map[s
 
 			textBuilder = s.defaultAlbumFolderTemplate
 			_ = textBuilder.Execute(&buffer, sanitizedTags) //nolint:errcheck // Default template is always valid.
-			//_ = textBuilder.Execute(&buffer, tags) //nolint:errcheck // Default template is always valid.
 		}
 	} else {
 		// Use default template if custom template is nil.
 		textBuilder = s.defaultAlbumFolderTemplate
 		_ = textBuilder.Execute(&buffer, sanitizedTags) //nolint:errcheck // Default template is always valid.
-		//_ = textBuilder.Execute(&buffer, tags) //nolint:errcheck // Default template is always valid.
 	}
 
 	// Unescape HTML entities in the generated folder name.

--- a/internal/service/zvuk/template_manager.go
+++ b/internal/service/zvuk/template_manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oshokin/zvuk-grabber/internal/config"
 	"github.com/oshokin/zvuk-grabber/internal/logger"
+	"github.com/oshokin/zvuk-grabber/internal/utils"
 )
 
 // TemplateManager defines the interface for managing templates used to generate filenames and folder names.
@@ -187,9 +188,16 @@ func (s *TemplateManagerImpl) GetAlbumFolderName(ctx context.Context, tags map[s
 		buffer      bytes.Buffer
 	)
 
+	var sanitizedTags = make(map[string]string, len(tags))
+	for key, val := range tags {
+		//fmt.Println(key, " -> ", val)
+		sanitizedTags[key] = utils.SanitizeFilename(val)
+	}
+
 	// Execute the template with the album tags.
 	if textBuilder != nil {
-		err := textBuilder.Execute(&buffer, tags)
+		err := textBuilder.Execute(&buffer, sanitizedTags)
+		//err := textBuilder.Execute(&buffer, tags)
 		if err != nil {
 			logger.Errorf(
 				ctx,
@@ -201,12 +209,14 @@ func (s *TemplateManagerImpl) GetAlbumFolderName(ctx context.Context, tags map[s
 			buffer.Reset()
 
 			textBuilder = s.defaultAlbumFolderTemplate
-			_ = textBuilder.Execute(&buffer, tags) //nolint:errcheck // Default template is always valid.
+			_ = textBuilder.Execute(&buffer, sanitizedTags) //nolint:errcheck // Default template is always valid.
+			//_ = textBuilder.Execute(&buffer, tags) //nolint:errcheck // Default template is always valid.
 		}
 	} else {
 		// Use default template if custom template is nil.
 		textBuilder = s.defaultAlbumFolderTemplate
-		_ = textBuilder.Execute(&buffer, tags) //nolint:errcheck // Default template is always valid.
+		_ = textBuilder.Execute(&buffer, sanitizedTags) //nolint:errcheck // Default template is always valid.
+		//_ = textBuilder.Execute(&buffer, tags) //nolint:errcheck // Default template is always valid.
 	}
 
 	// Unescape HTML entities in the generated folder name.

--- a/internal/service/zvuk/template_manager_test.go
+++ b/internal/service/zvuk/template_manager_test.go
@@ -166,7 +166,7 @@ func TestTemplateManagerImpl_GetAlbumFolderName(t *testing.T) {
 				"albumArtist": "Artist/With\\Special:Chars",
 				"albumTitle":  "Album|With*Special?Chars",
 			},
-			expected: "2023 - Artist/With\\Special:Chars - Album|With*Special?Chars",
+			expected: "2023 - Artist_With_Special_Chars - Album_With_Special_Chars",
 		},
 	}
 


### PR DESCRIPTION
The thing is each time we encounter artist name or album name with slash in it (either `/` or `\`) it is treated as file path separator (within `album.generateSanitizedFolderPath:200`) rather than special character that should be sanitized in `utils.SanitizeFileName`.
Thus when the code is trying to create directory for album it goes ballistic as shown in [this issue](https://github.com/oshokin/zvuk-grabber/issues/14).

P.S.: I am not a gofer, moreover I am not much of a programmer at all, I've just made ad-hoc changes in target function and fixed corresponding test, it probably requires the same changes for podcast and audiobook folders

